### PR TITLE
removed docker-compose

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,9 +1,0 @@
-version: '3.4'
-
-services: 
-    logbook-api:
-        build: .
-        volumes:
-            - .:/user/src/app
-        ports: 
-            - 5000:5000


### PR DESCRIPTION
No need for docker-compose at this point, just need one docker container for flask app